### PR TITLE
feat: generate schema

### DIFF
--- a/liveview/lib/rot_raven/vehicle/car.ex
+++ b/liveview/lib/rot_raven/vehicle/car.ex
@@ -1,0 +1,22 @@
+defmodule RotRaven.Vehicle.Car do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_cars" do
+    field :maker, :string
+    field :name, :string
+    field :prime_mover_id, :id
+    field :transmission_id, :id
+    field :front_tire_id, :id
+    field :rear_tire_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(car, attrs) do
+    car
+    |> cast(attrs, [:name, :maker])
+    |> validate_required([:name, :maker])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/maker.ex
+++ b/liveview/lib/rot_raven/vehicle/maker.ex
@@ -1,0 +1,16 @@
+defmodule RotRaven.Vehicle.Maker do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_makers" do
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(maker, attrs) do
+    maker
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/prime_mover.ex
+++ b/liveview/lib/rot_raven/vehicle/prime_mover.ex
@@ -1,0 +1,19 @@
+defmodule RotRaven.Vehicle.PrimeMover do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_prime_movers" do
+    field :model, :string
+    field :engine_id, :id
+    field :electric_motor_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(prime_mover, attrs) do
+    prime_mover
+    |> cast(attrs, [:model])
+    |> validate_required([:model])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/prime_mover/electric_motor.ex
+++ b/liveview/lib/rot_raven/vehicle/prime_mover/electric_motor.ex
@@ -1,0 +1,23 @@
+defmodule RotRaven.Vehicle.PrimeMover.ElectricMotor do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_electoric_motors" do
+    field :max_kw, :decimal
+    field :max_kw_max_range, :integer
+    field :max_kw_min_range, :integer
+    field :max_nm, :decimal
+    field :max_nm_max_range, :integer
+    field :max_nm_min_range, :integer
+    field :model, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(electric_motor, attrs) do
+    electric_motor
+    |> cast(attrs, [:model, :max_kw, :max_kw_min_range, :max_kw_max_range, :max_nm, :max_nm_min_range, :max_nm_max_range])
+    |> validate_required([:model, :max_kw, :max_kw_min_range, :max_kw_max_range, :max_nm, :max_nm_min_range, :max_nm_max_range])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/prime_mover/engine.ex
+++ b/liveview/lib/rot_raven/vehicle/prime_mover/engine.ex
@@ -1,0 +1,26 @@
+defmodule RotRaven.Vehicle.PrimeMover.Engine do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_engines" do
+    field :cylinder, :integer
+    field :displacement, :integer
+    field :max_kw, :decimal
+    field :max_kw_max_range, :integer
+    field :max_kw_min_range, :integer
+    field :max_nm, :decimal
+    field :max_nm_max_range, :integer
+    field :max_nm_min_range, :integer
+    field :model, :string
+    field :valve_mechanism, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(engine, attrs) do
+    engine
+    |> cast(attrs, [:model, :displacement, :cylinder, :valve_mechanism, :max_kw, :max_kw_min_range, :max_kw_max_range, :max_nm, :max_nm_min_range, :max_nm_max_range])
+    |> validate_required([:model, :displacement, :cylinder, :valve_mechanism, :max_kw, :max_kw_min_range, :max_kw_max_range, :max_nm, :max_nm_min_range, :max_nm_max_range])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/tire.ex
+++ b/liveview/lib/rot_raven/vehicle/tire.ex
@@ -1,0 +1,19 @@
+defmodule RotRaven.Vehicle.Tire do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_tires" do
+    field :flatness, :integer
+    field :is_radial, :boolean, default: false
+    field :width, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tire, attrs) do
+    tire
+    |> cast(attrs, [:is_radial, :width, :flatness])
+    |> validate_required([:is_radial, :width, :flatness])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/tire/road_index.ex
+++ b/liveview/lib/rot_raven/vehicle/tire/road_index.ex
@@ -1,0 +1,17 @@
+defmodule RotRaven.Vehicle.Tire.RoadIndex do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_tire_road_indexes" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(road_index, attrs) do
+    road_index
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/transmission.ex
+++ b/liveview/lib/rot_raven/vehicle/transmission.ex
@@ -1,0 +1,18 @@
+defmodule RotRaven.Vehicle.Transmission do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_transmissions" do
+    field :type_id, :id
+    field :clutch_type_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(transmission, attrs) do
+    transmission
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/transmission/clutch_type.ex
+++ b/liveview/lib/rot_raven/vehicle/transmission/clutch_type.ex
@@ -1,0 +1,17 @@
+defmodule RotRaven.Vehicle.Transmission.ClutchType do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_transmission_clutch_types" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(clutch_type, attrs) do
+    clutch_type
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/transmission/gear.ex
+++ b/liveview/lib/rot_raven/vehicle/transmission/gear.ex
@@ -1,0 +1,17 @@
+defmodule RotRaven.Vehicle.Transmission.Gear do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_transmission_gears" do
+    field :type, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(gear, attrs) do
+    gear
+    |> cast(attrs, [:type])
+    |> validate_required([:type])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/transmission/gear/ratio.ex
+++ b/liveview/lib/rot_raven/vehicle/transmission/gear/ratio.ex
@@ -1,0 +1,19 @@
+defmodule RotRaven.Vehicle.Transmission.Gear.Ratio do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_transmission_gear_ratios" do
+    field :no, :integer
+    field :ratio, :decimal
+    field :gear_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(ratio, attrs) do
+    ratio
+    |> cast(attrs, [:no, :ratio])
+    |> validate_required([:no, :ratio])
+  end
+end

--- a/liveview/lib/rot_raven/vehicle/transmission/type.ex
+++ b/liveview/lib/rot_raven/vehicle/transmission/type.ex
@@ -1,0 +1,17 @@
+defmodule RotRaven.Vehicle.Transmission.Type do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "vehicle_transmission_types" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(type, attrs) do
+    type
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/liveview/lib/rot_raven_web/live/gps_record.ex
+++ b/liveview/lib/rot_raven_web/live/gps_record.ex
@@ -112,25 +112,28 @@ defmodule RotRavenWeb.GpsRecord do
     """
   end
 
-  def mount( _session, socket ) do
+  def mount(_session, socket) do
     GpsRecord.get_all_gpsrecord() |> IO.inspect()
+
     {
       :ok,
       assign(socket, records: GpsRecord.get_all_gpsrecord(), records_json: "")
     }
   end
 
-  def handle_event("submit", %{ "records_json" => records_json }, socket) do
+  def handle_event("submit", %{"records_json" => records_json}, socket) do
     IO.inspect("handle_event function called.")
     send(self(), {:submit, records_json})
-    {:noreply, assign(socket, records: [], records_json: records_json ) }
+    {:noreply, assign(socket, records: [], records_json: records_json)}
   end
 
   def handle_info({:submit, records_json}, socket) do
     IO.inspect("handle_info function called.")
+
     records_json
     |> Poison.decode!()
-    |> Enum.each( &%GpsRecord{} |> GpsRecord.changeset(&1) |> RotRaven.Repo.insert!() )
+    |> Enum.each(&(%GpsRecord{} |> GpsRecord.changeset(&1) |> RotRaven.Repo.insert!()))
+
     {:noreply, assign(socket, records: Poison.decode!(records_json))}
   end
 end

--- a/liveview/priv/repo/migrations/20190731140510_create_vehicle_prime_movers.exs
+++ b/liveview/priv/repo/migrations/20190731140510_create_vehicle_prime_movers.exs
@@ -1,0 +1,16 @@
+defmodule RotRaven.Repo.Migrations.CreateVehiclePrimeMovers do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_prime_movers) do
+      add :model, :string
+      add :engine_id, references(:engines, on_delete: :nothing)
+      add :electric_motor_id, references(:electoric_motors, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:vehicle_prime_movers, [:engine_id])
+    create index(:vehicle_prime_movers, [:electric_motor_id])
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140722_create_vehicle_engines.exs
+++ b/liveview/priv/repo/migrations/20190731140722_create_vehicle_engines.exs
@@ -1,0 +1,21 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleEngines do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_engines) do
+      add :model, :string
+      add :displacement, :integer
+      add :cylinder, :integer
+      add :valve_mechanism, :string
+      add :max_kw, :decimal
+      add :max_kw_min_range, :integer
+      add :max_kw_max_range, :integer
+      add :max_nm, :decimal
+      add :max_nm_min_range, :integer
+      add :max_nm_max_range, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140732_create_vehicle_electoric_motors.exs
+++ b/liveview/priv/repo/migrations/20190731140732_create_vehicle_electoric_motors.exs
@@ -1,0 +1,18 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleElectoricMotors do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_electoric_motors) do
+      add :model, :string
+      add :max_kw, :decimal
+      add :max_kw_min_range, :integer
+      add :max_kw_max_range, :integer
+      add :max_nm, :decimal
+      add :max_nm_min_range, :integer
+      add :max_nm_max_range, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140746_create_vehicle_transmissions.exs
+++ b/liveview/priv/repo/migrations/20190731140746_create_vehicle_transmissions.exs
@@ -1,0 +1,15 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTransmissions do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_transmissions) do
+      add :type_id, references(:vehicle_transmission_types, on_delete: :nothing)
+      add :clutch_type_id, references(:vehicle_transmission_clutch_types, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:vehicle_transmissions, [:type_id])
+    create index(:vehicle_transmissions, [:clutch_type_id])
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140755_create_vehicle_transmission_clutch_types.exs
+++ b/liveview/priv/repo/migrations/20190731140755_create_vehicle_transmission_clutch_types.exs
@@ -1,0 +1,12 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTransmissionClutchTypes do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_transmission_clutch_types) do
+      add :name, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140806_create_vehicle_transmission_gears.exs
+++ b/liveview/priv/repo/migrations/20190731140806_create_vehicle_transmission_gears.exs
@@ -1,0 +1,12 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTransmissionGears do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_transmission_gears) do
+      add :type, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140816_create_vehicle_transmission_gear_ratios.exs
+++ b/liveview/priv/repo/migrations/20190731140816_create_vehicle_transmission_gear_ratios.exs
@@ -1,0 +1,15 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTransmissionGearRatios do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_transmission_gear_ratios) do
+      add :no, :integer
+      add :ratio, :decimal
+      add :gear_id, references(:vehicle_transmission_gear, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:vehicle_transmission_gear_ratios, [:gear_id])
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140831_create_vehicle_transmission_types.exs
+++ b/liveview/priv/repo/migrations/20190731140831_create_vehicle_transmission_types.exs
@@ -1,0 +1,12 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTransmissionTypes do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_transmission_types) do
+      add :name, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140904_create_vehicle_tires.exs
+++ b/liveview/priv/repo/migrations/20190731140904_create_vehicle_tires.exs
@@ -1,0 +1,14 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTires do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_tires) do
+      add :is_radial, :boolean, default: false, null: false
+      add :width, :integer
+      add :flatness, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731140919_create_vehicle_tire_road_indexes.exs
+++ b/liveview/priv/repo/migrations/20190731140919_create_vehicle_tire_road_indexes.exs
@@ -1,0 +1,12 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleTireRoadIndexes do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_tire_road_indexes) do
+      add :name, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/liveview/priv/repo/migrations/20190731142157_create_vehicle_cars.exs
+++ b/liveview/priv/repo/migrations/20190731142157_create_vehicle_cars.exs
@@ -1,0 +1,21 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleCars do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_cars) do
+      add :name, :string
+      add :maker, :string
+      add :prime_mover_id, references(:vehicle_prime_movers, on_delete: :nothing)
+      add :transmission_id, references(:vehicle_transmissions, on_delete: :nothing)
+      add :front_tire_id, references(:vehicle_tires, on_delete: :nothing)
+      add :rear_tire_id, references(:vehicle_tires, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:vehicle_cars, [:prime_mover_id])
+    create index(:vehicle_cars, [:transmission_id])
+    create index(:vehicle_cars, [:front_tire_id])
+    create index(:vehicle_cars, [:rear_tire_id])
+  end
+end

--- a/liveview/priv/repo/migrations/20190731142211_create_vehicle_makers.exs
+++ b/liveview/priv/repo/migrations/20190731142211_create_vehicle_makers.exs
@@ -1,0 +1,11 @@
+defmodule RotRaven.Repo.Migrations.CreateVehicleMakers do
+  use Ecto.Migration
+
+  def change do
+    create table(:vehicle_makers) do
+
+      timestamps()
+    end
+
+  end
+end


### PR DESCRIPTION
#16 

生成時のコマンド

```sh
docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Car \
    vehicle_cars \
      name:string \
      maker:string \
      prime_mover_id:references:vehicle_prime_movers \
      transmission_id:references:vehicle_transmissions \
      front_tire_id:references:vehicle_tires \
      rear_tire_id:references:vehicle_tires

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Maker \
    vehicle_makers

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.PrimeMover \
    vehicle_prime_movers \
      model:string \
      engine_id:references:engines \
      electric_motor_id:references:electoric_motors

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.PrimeMover.Engine \
    vehicle_engines \
      model:string \
      displacement:integer \
      cylinder:integer \
      valve_mechanism:string \
      max_kw:decimal \
      max_kw_min_range:integer \
      max_kw_max_range:integer \
      max_nm:decimal \
      max_nm_min_range:integer \
      max_nm_max_range:integer
      

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.PrimeMover.ElectricMotor \
    vehicle_electoric_motors \
      model:string \
      max_kw:decimal \
      max_kw_min_range:integer \
      max_kw_max_range:integer \
      max_nm:decimal \
      max_nm_min_range:integer \
      max_nm_max_range:integer

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Transmission \
    vehicle_transmissions \
      type_id:references:vehicle_transmission_types \
      clutch_type_id:references:vehicle_transmission_clutch_types

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Transmission.ClutchType \
    vehicle_transmission_clutch_types \
      name:string

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Transmission.Gear \
    vehicle_transmission_gears \
      type:string

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Transmission.Gear.Ratio \
    vehicle_transmission_gear_ratios \
      gear_id:references:vehicle_transmission_gear \
      no:integer \
      ratio:decimal

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Transmission.Type \
    vehicle_transmission_types \
      name:string

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Tire \
    vehicle_tires \
      is_radial:boolean \
      width:integer \
      flatness:integer
      wheel_inch:integer
      road_index_id:references:vehicle_tire_road_indexes \
      speed_range_id:references:vehicle_tire_speed_ranges

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Tire.RoadIndex \
    vehicle_tire_road_indexes \
      name:string

docker-compose -f docker-compose.yml -f docker-compose-dev.yml run --rm liveview \
  mix phx.gen.schema \
    Vehicle.Tire.SpeedRange \
    vehicle_tire_speed_ranges \
      name:string
```