### PR TITLE
Issue/33/test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     image: donnex/pgweb
     ports:
       - "18080:8080"
-    # command: ["-s", "--bind=0.0.0.0", "--listen=8080", "--host=postgres", "--ssl=disable", "--user=postgres", "--pass=postgres"]
+    command: ["-s", "--bind=0.0.0.0", "--listen=8080", "--host=postgres", "--ssl=disable", "--user=postgres", "--pass=postgres"]
     depends_on:
       - postgres
 

--- a/liveview/config/test.exs
+++ b/liveview/config/test.exs
@@ -4,8 +4,8 @@ use Mix.Config
 config :rot_raven, RotRaven.Repo,
   username: "postgres",
   password: "postgres",
-  database: "rot_raven_test",
-  hostname: "localhost",
+  database: "rot_raven_liveview_test",
+  hostname: "postgres",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,


### PR DESCRIPTION
ref: #33 
`test.exs`に不備があったことが原因だった。